### PR TITLE
fix: iter return result

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or edit your `Cargo.toml` and add `serde_columnar` as dependency:
 
 ```toml
 [dependencies]
-serde_columnar = "0.3.2"
+serde_columnar = "0.3.3"
 ```
 
 ### Container Attribute

--- a/columnar/examples/iterable_fields.rs
+++ b/columnar/examples/iterable_fields.rs
@@ -71,6 +71,7 @@ pub struct ComplexData<'a> {
     #[columnar(borrow)]
     borrow_str: Cow<'a, str>,
     #[columnar(skip)]
+    #[allow(dead_code)]
     skip: bool,
     #[columnar(class = "vec", iter = "Data<'a>")]
     vec: Vec<ComplexData<'a>>,
@@ -110,7 +111,7 @@ fn main() {
     let iter_store = iter_from_bytes::<VecStore>(&bytes).unwrap();
     // println!("data len {}", iter_store.data.count());
     for data in iter_store.data {
-        println!("# {:?}", data)
+        println!("# {:?}", data.unwrap())
     }
     assert_eq!(iter_store.id, 7)
 }

--- a/columnar/src/column/mod.rs
+++ b/columnar/src/column/mod.rs
@@ -22,7 +22,6 @@ pub trait ColumnTrait {
     }
 }
 
-
 // TODO: remove index
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ColumnAttr {
@@ -31,7 +30,7 @@ pub struct ColumnAttr {
 
 impl ColumnAttr {
     pub(crate) fn empty() -> Self {
-        return Self { index: None };
+        Self { index: None }
     }
 }
 

--- a/columnar_derive/src/derive/map.rs
+++ b/columnar_derive/src/derive/map.rs
@@ -46,7 +46,7 @@ pub fn generate_derive_hashmap_row_ser(
 
 pub fn generate_derive_hashmap_row_de(
     input: &DeriveInput,
-    field_args: &Vec<FieldArgs>,
+    field_args: &[FieldArgs],
 ) -> syn::Result<proc_macro2::TokenStream> {
     let struct_name_ident = &input.ident;
     let generics_params_to_modify = input.generics.clone();
@@ -142,7 +142,7 @@ fn process_map_generics<'a>(
 }
 
 fn generate_with_map_per_columns(
-    field_args: &Vec<FieldArgs>,
+    field_args: &[FieldArgs],
 ) -> syn::Result<proc_macro2::TokenStream> {
     let mut columns_quote = Vec::with_capacity(field_args.len());
     let mut columns_types = Vec::with_capacity(field_args.len());
@@ -252,7 +252,7 @@ fn encode_map_per_column_to_ser(
 }
 
 fn generate_map_per_column_to_de_columns(
-    field_args: &Vec<FieldArgs>,
+    field_args: &[FieldArgs],
     input: &DeriveInput,
 ) -> syn::Result<proc_macro2::TokenStream> {
     let struct_name = &input.ident;
@@ -264,7 +264,7 @@ fn generate_map_per_column_to_de_columns(
     let mut field_names = Vec::with_capacity(field_len);
     let mut field_names_build = Vec::with_capacity(field_len);
     let mut into_iter_quote = Vec::with_capacity(field_len);
-    for (_, args) in field_args.iter().enumerate() {
+    for args in field_args.iter() {
         let field_name = &args.ident;
         let optional = args.optional;
         let index = args.index;

--- a/columnar_derive/src/derive/vec.rs
+++ b/columnar_derive/src/derive/vec.rs
@@ -134,7 +134,7 @@ fn generate_per_field_to_column(field_arg: &FieldArgs) -> syn::Result<proc_macro
     Ok(ret)
 }
 
-fn encode_per_column_to_ser(field_args: &Vec<FieldArgs>) -> syn::Result<proc_macro2::TokenStream> {
+fn encode_per_column_to_ser(field_args: &[FieldArgs]) -> syn::Result<proc_macro2::TokenStream> {
     let mut field_len = field_args.len();
     let mut ser_elements = Vec::with_capacity(field_len);
     for args in field_args.iter() {
@@ -174,7 +174,7 @@ fn encode_per_column_to_ser(field_args: &Vec<FieldArgs>) -> syn::Result<proc_mac
 // Deserialize
 pub fn generate_derive_vec_row_de(
     input: &DeriveInput,
-    field_args: &Vec<FieldArgs>,
+    field_args: &[FieldArgs],
 ) -> syn::Result<proc_macro2::TokenStream> {
     let struct_name_ident = &input.ident;
     let generics_params_to_modify = input.generics.clone();
@@ -230,7 +230,7 @@ pub fn generate_derive_vec_row_de(
 }
 
 fn generate_per_column_to_de_columns(
-    field_args: &Vec<FieldArgs>,
+    field_args: &[FieldArgs],
     input: &DeriveInput,
 ) -> syn::Result<proc_macro2::TokenStream> {
     let struct_name = &input.ident;
@@ -242,7 +242,7 @@ fn generate_per_column_to_de_columns(
     let mut into_iter_quote = Vec::with_capacity(field_len);
     let mut field_names = Vec::with_capacity(field_len);
     let mut field_names_build = Vec::with_capacity(field_len);
-    for (_, args) in field_args.iter().enumerate() {
+    for args in field_args.iter() {
         let field_name = &args.ident;
         let optional = args.optional;
         let index = args.index;


### PR DESCRIPTION
This PR makes `iter` to return `Result` instead of `unwrap()` directly.

If this PR is approved, I will publish `v0.3.4`.